### PR TITLE
Introduce rubocop-rbs_inline plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.2'
           - '3.3'
           - '3.4'
           - '4.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 plugins:
   - rubocop-numbered-params

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,12 +4,22 @@ AllCops:
 plugins:
   - rubocop-numbered-params
   - rubocop-rake
+  - rubocop-rbs_inline
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
 
 Style/Documentation:
   Enabled: false
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never
 
 Style/StringLiterals:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rake", "~> 13.4"
 gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
 gem "rubocop-rake"
+gem "rubocop-rbs_inline"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
+    rubocop-rbs_inline (1.6.0)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
@@ -237,6 +241,7 @@ DEPENDENCIES
   rubocop (~> 1.88)
   rubocop-numbered-params
   rubocop-rake
+  rubocop-rbs_inline
   steep
 
 BUNDLED WITH

--- a/lib/generators/rbs_draper/install_generator.rb
+++ b/lib/generators/rbs_draper/install_generator.rb
@@ -4,7 +4,7 @@ require "rails"
 
 module RbsDraper
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask
+    def create_raketask #: void
       create_file "lib/tasks/rbs_draper.rake", <<~RUBY
         begin
           # frozen_string_literal: true

--- a/lib/rbs_draper/decoratable.rb
+++ b/lib/rbs_draper/decoratable.rb
@@ -4,8 +4,7 @@ require "draper"
 
 module RbsDraper
   module Decoratable
-    #: () -> Array[singleton(Draper::Decoratable)]
-    def self.all
+    def self.all #: Array[singleton(Draper::Decoratable)]
       ObjectSpace.each_object.select do |obj|
         obj.is_a?(Class) && obj < ::Draper::Decoratable && obj.decorator_class
       rescue StandardError
@@ -13,8 +12,8 @@ module RbsDraper
       end
     end
 
-    #: (singleton(Draper::Decoratable) klass) -> String
-    def self.class_to_rbs(klass)
+    # @rbs klass: singleton(Draper::Decoratable)
+    def self.class_to_rbs(klass) #: String
       Generator.new(klass).generate
     end
 
@@ -22,14 +21,13 @@ module RbsDraper
       attr_reader :klass #: singleton(Draper::Decoratable)
       attr_reader :klass_name #: String
 
-      #: (singleton(Draper::Decoratable) klass) -> void
-      def initialize(klass)
+      # @rbs klass: singleton(Draper::Decoratable)
+      def initialize(klass) #: void
         @klass = klass
         @klass_name = klass.name || ""
       end
 
-      #: () -> String
-      def generate
+      def generate #: String
         format <<~RBS
           #{header}
           #{method_decls}
@@ -39,16 +37,15 @@ module RbsDraper
 
       private
 
-      #: (String rbs) -> String
-      def format(rbs)
+      # @rbs rbs: String
+      def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
           RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
         end.string
       end
 
-      #: () -> String
-      def header
+      def header #: String
         namespace = +""
         klass_name.split("::").map do |mod_name|
           namespace += "::#{mod_name}"
@@ -68,18 +65,15 @@ module RbsDraper
         end.join("\n")
       end
 
-      #: () -> String
-      def method_decls
+      def method_decls #: String
         "def decorate: () -> #{klass.decorator_class.name}"
       end
 
-      #: () -> String
-      def footer
+      def footer #: String
         "end\n" * klass.module_parents.size
       end
 
-      #: () -> Array[String]
-      def module_names
+      def module_names #: Array[String]
         klass.module_parents.reverse[1..].map do |mod|
           mod.name.split("::").last
         end

--- a/lib/rbs_draper/decorator.rb
+++ b/lib/rbs_draper/decorator.rb
@@ -8,8 +8,7 @@ module RbsDraper
     # @rbs klass: singleton(Draper::Decorator)
     # @rbs rbs_builder: RBS::DefinitionBuilder
     # @rbs decorated_class: singleton(Class)?
-    # @rbs return: String?
-    def self.class_to_rbs(klass, rbs_builder, decorated_class: nil)
+    def self.class_to_rbs(klass, rbs_builder, decorated_class: nil) #: String?
       Generator.new(klass, rbs_builder, decorated_class: decorated_class).generate
     end
 
@@ -26,16 +25,14 @@ module RbsDraper
       # @rbs klass: singleton(Draper::Decorator)
       # @rbs rbs_builder: RBS::DefinitionBuilder
       # @rbs decorated_class: singleton(Class)?
-      # @rbs return: void
-      def initialize(klass, rbs_builder, decorated_class: nil)
+      def initialize(klass, rbs_builder, decorated_class: nil) #: void
         @klass = klass
         @klass_name = klass.name || ""
         @rbs_builder = rbs_builder
         @decorated_class = decorated_class
       end
 
-      #: () -> String?
-      def generate
+      def generate #: String?
         return if decorated_class_def.blank?
 
         format <<~RBS
@@ -51,16 +48,15 @@ module RbsDraper
 
       private
 
-      #: (String rbs) -> String
-      def format(rbs)
+      # @rbs rbs: String
+      def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
           RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
         end.string
       end
 
-      #: () -> String
-      def header
+      def header #: String
         namespace = +""
         klass_name.split("::").map do |mod_name|
           namespace += "::#{mod_name}"
@@ -80,18 +76,15 @@ module RbsDraper
         end.join("\n")
       end
 
-      #: () -> String?
-      def mixin_decls
+      def mixin_decls #: String?
         "extend Draper::Finders[#{decorated_class_name}]" if klass.singleton_class < Draper::Finders
       end
 
-      #: () -> String?
-      def class_method_decls
+      def class_method_decls #: String?
         "def self.decorate: (#{decorated_class_name} object, **untyped options) -> self"
       end
 
-      #: () -> String
-      def object_method_decls
+      def object_method_decls #: String
         if decorated_class_name.include?("::")
           <<~RBS
             def initialize: (#{decorated_class_name} object, **untyped options) -> void
@@ -106,8 +99,7 @@ module RbsDraper
         end
       end
 
-      #: () -> String?
-      def method_decls
+      def method_decls #: String?
         delegated_methods.filter_map do |name, method|
           next if user_defined_class&.methods&.fetch(name, nil)
 
@@ -115,33 +107,28 @@ module RbsDraper
         end.join("\n")
       end
 
-      #: () -> String
-      def footer
+      def footer #: String
         "end\n" * klass.module_parents.size
       end
 
-      #: () -> Array[String]
-      def module_names
+      def module_names #: Array[String]
         klass.module_parents.reverse[1..].map do |mod|
           mod.name.split("::").last
         end
       end
 
-      #: () -> RBS::Definition?
-      def decorated_class_def
+      def decorated_class_def #: RBS::Definition?
         type_name = RBS::TypeName.parse(decorated_class_name).absolute!
         @decorated_class_def ||= rbs_builder.build_instance(type_name)
       rescue StandardError
         nil
       end
 
-      #: () -> String
-      def decorated_class_name
+      def decorated_class_name #: String
         @decorated_class_name = decorated_class&.name || klass.object_class.name.to_s
       end
 
-      #: () -> Array[[Symbol, RBS::Definition::Method]]
-      def delegated_methods
+      def delegated_methods #: Array[[Symbol, RBS::Definition::Method]]
         return [] unless klass.ancestors.include? ::Draper::AutomaticDelegation
 
         decorated_klass = decorated_class_def
@@ -155,8 +142,7 @@ module RbsDraper
         end
       end
 
-      #: () -> RBS::Definition?
-      def user_defined_class
+      def user_defined_class #: RBS::Definition?
         type_name = RBS::TypeName.parse(klass.name.to_s).absolute!
         @user_defined_class ||= rbs_builder.build_instance(type_name)
       rescue StandardError

--- a/lib/rbs_draper/rake_task.rb
+++ b/lib/rbs_draper/rake_task.rb
@@ -14,8 +14,9 @@ module RbsDraper
 
     # @rbs @rbs_builder: RBS::DefinitionBuilder
 
-    #: (?Symbol name) ?{ (RakeTask) -> void } -> void
-    def initialize(name = :'rbs:draper', &block)
+    # @rbs name: Symbol
+    # @rbs &block: ?(RakeTask) -> void
+    def initialize(name = :'rbs:draper', &block) #: void
       super()
 
       @name = name
@@ -31,8 +32,7 @@ module RbsDraper
       define_setup_task
     end
 
-    #: () -> void
-    def define_setup_task
+    def define_setup_task #: void
       desc "Run all tasks of rbs_draper"
 
       deps = [:"#{name}:clean", :"#{name}:base_class:generate", :"#{name}:decoratables:generate",
@@ -40,16 +40,14 @@ module RbsDraper
       task("#{name}:setup": deps)
     end
 
-    #: () -> void
-    def define_clean_task
+    def define_clean_task #: void
       desc "Clean up generated RBS files"
       task("#{name}:clean": :environment) do
         sh "rm", "-rf", signature_root_dir.to_s
       end
     end
 
-    #: () -> void
-    def define_base_class_generate_task
+    def define_base_class_generate_task #: void
       desc "Generate RBS files for base classes"
       task("#{name}:base_class:generate": :environment) do
         require "rbs_draper" # load RbsDraper lazily
@@ -62,8 +60,7 @@ module RbsDraper
       end
     end
 
-    #: () -> void
-    def define_decoratables_generate_task
+    def define_decoratables_generate_task #: void
       desc "Generate RBS files for decoratable models"
       task("#{name}:decoratables:generate": :environment) do
         require "rbs_draper" # load RbsDraper lazily
@@ -79,8 +76,7 @@ module RbsDraper
       end
     end
 
-    #: () -> void
-    def define_decorators_generate_task
+    def define_decorators_generate_task #: void
       desc "Generate RBS files for decorators"
       task("#{name}:decorators:generate": :environment) do
         Rails.application.eager_load!
@@ -97,8 +93,7 @@ module RbsDraper
 
     private
 
-    #: () -> RBS::DefinitionBuilder
-    def rbs_builder
+    def rbs_builder #: RBS::DefinitionBuilder
       return @rbs_builder if @rbs_builder
 
       loader = RBS::CLI::LibraryOptions.new.loader

--- a/rbs_draper.gemspec
+++ b/rbs_draper.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A RBS files generator for Draper decorators"
   spec.homepage = "https://github.com/tk0miya/rbs_draper"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/sig/generators/rbs_draper/install_generator.rbs
+++ b/sig/generators/rbs_draper/install_generator.rbs
@@ -2,6 +2,6 @@
 
 module RbsDraper
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask: () -> untyped
+    def create_raketask: () -> void
   end
 end

--- a/sig/rbs_draper/decoratable.rbs
+++ b/sig/rbs_draper/decoratable.rbs
@@ -2,10 +2,9 @@
 
 module RbsDraper
   module Decoratable
-    # : () -> Array[singleton(Draper::Decoratable)]
     def self.all: () -> Array[singleton(Draper::Decoratable)]
 
-    # : (singleton(Draper::Decoratable) klass) -> String
+    # @rbs klass: singleton(Draper::Decoratable)
     def self.class_to_rbs: (singleton(Draper::Decoratable) klass) -> String
 
     class Generator
@@ -13,27 +12,22 @@ module RbsDraper
 
       attr_reader klass_name: String
 
-      # : (singleton(Draper::Decoratable) klass) -> void
+      # @rbs klass: singleton(Draper::Decoratable)
       def initialize: (singleton(Draper::Decoratable) klass) -> void
 
-      # : () -> String
       def generate: () -> String
 
       private
 
-      # : (String rbs) -> String
+      # @rbs rbs: String
       def format: (String rbs) -> String
 
-      # : () -> String
       def header: () -> String
 
-      # : () -> String
       def method_decls: () -> String
 
-      # : () -> String
       def footer: () -> String
 
-      # : () -> Array[String]
       def module_names: () -> Array[String]
     end
   end

--- a/sig/rbs_draper/decorator.rbs
+++ b/sig/rbs_draper/decorator.rbs
@@ -5,7 +5,6 @@ module RbsDraper
     # @rbs klass: singleton(Draper::Decorator)
     # @rbs rbs_builder: RBS::DefinitionBuilder
     # @rbs decorated_class: singleton(Class)?
-    # @rbs return: String?
     def self.class_to_rbs: (singleton(Draper::Decorator) klass, RBS::DefinitionBuilder rbs_builder, ?decorated_class: singleton(Class)?) -> String?
 
     class Generator
@@ -26,48 +25,35 @@ module RbsDraper
       # @rbs klass: singleton(Draper::Decorator)
       # @rbs rbs_builder: RBS::DefinitionBuilder
       # @rbs decorated_class: singleton(Class)?
-      # @rbs return: void
       def initialize: (singleton(Draper::Decorator) klass, RBS::DefinitionBuilder rbs_builder, ?decorated_class: singleton(Class)?) -> void
 
-      # : () -> String?
       def generate: () -> String?
 
       private
 
-      # : (String rbs) -> String
+      # @rbs rbs: String
       def format: (String rbs) -> String
 
-      # : () -> String
       def header: () -> String
 
-      # : () -> String?
       def mixin_decls: () -> String?
 
-      # : () -> String?
       def class_method_decls: () -> String?
 
-      # : () -> String
       def object_method_decls: () -> String
 
-      # : () -> String?
       def method_decls: () -> String?
 
-      # : () -> String
       def footer: () -> String
 
-      # : () -> Array[String]
       def module_names: () -> Array[String]
 
-      # : () -> RBS::Definition?
       def decorated_class_def: () -> RBS::Definition?
 
-      # : () -> String
       def decorated_class_name: () -> String
 
-      # : () -> Array[[Symbol, RBS::Definition::Method]]
       def delegated_methods: () -> Array[[ Symbol, RBS::Definition::Method ]]
 
-      # : () -> RBS::Definition?
       def user_defined_class: () -> RBS::Definition?
     end
   end

--- a/sig/rbs_draper/rake_task.rbs
+++ b/sig/rbs_draper/rake_task.rbs
@@ -10,27 +10,22 @@ module RbsDraper
 
     @rbs_builder: RBS::DefinitionBuilder
 
-    # : (?Symbol name) ?{ (RakeTask) -> void } -> void
+    # @rbs name: Symbol
+    # @rbs &block: ?(RakeTask) -> void
     def initialize: (?Symbol name) ?{ (RakeTask) -> void } -> void
 
-    # : () -> void
     def define_setup_task: () -> void
 
-    # : () -> void
     def define_clean_task: () -> void
 
-    # : () -> void
     def define_base_class_generate_task: () -> void
 
-    # : () -> void
     def define_decoratables_generate_task: () -> void
 
-    # : () -> void
     def define_decorators_generate_task: () -> void
 
     private
 
-    # : () -> RBS::DefinitionBuilder
     def rbs_builder: () -> RBS::DefinitionBuilder
   end
 end


### PR DESCRIPTION
Add the `rubocop-rbs_inline` plugin so this repository lints its RBS::Inline annotations, aligning it with the other repositories that already enable the full plugin set (numbered-params, rake, rbs_inline, rspec).

This PR contains two commits:

### Introduce rubocop-rbs_inline plugin
- Add `rubocop-rbs_inline` to the Gemfile and lockfile (using **1.6.0**, whose defaults exclude `spec/` from the `Style/RbsInline` cops, so no explicit `Exclude` is needed)
- Register it under `plugins:` in `.rubocop.yml`
- Configure the `Style/RbsInline/*` cops with the same settings used across the sibling repositories (`doc_style_and_return_annotation`, `RequireRbsInlineComment: never`)
- Convert the existing `#: (Type) -> ReturnType` full-signature annotations to doc-style parameters plus trailing return annotations. The regenerated signatures under `sig/` are identical, except `InstallGenerator#create_raketask`, which gains an explicit `#: void` (`untyped` → `void`) to match the sibling generators.

### Drop Ruby 3.2 support
`rubocop-rbs_inline` requires Ruby >= 3.3, so drop 3.2 from the CI matrix, bump `required_ruby_version`, and raise `TargetRubyVersion` to 3.3.

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)