### PR TITLE
Introduce rubocop-rspec plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ plugins:
   - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
+  - rubocop-rspec
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
@@ -41,3 +42,6 @@ Metrics/BlockLength:
 
 Metrics/MethodLength:
   Max: 20
+
+RSpec/NamedSubject:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
+gem "rubocop-rspec"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,10 @@ GEM
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)
+    rubocop-rspec (3.10.2)
+      lint_roller (~> 1.1)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
@@ -242,6 +246,7 @@ DEPENDENCIES
   rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
+  rubocop-rspec
   steep
 
 BUNDLED WITH

--- a/spec/rbs_draper/decoratable_spec.rb
+++ b/spec/rbs_draper/decoratable_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RbsDraper::Decoratable do
     subject { described_class.all }
 
     it "returns a list of decoratables" do
-      is_expected.to contain_exactly(Account, Article)
+      expect(subject).to contain_exactly(Account, Article)
     end
   end
 

--- a/spec/rbs_draper/decorator_spec.rb
+++ b/spec/rbs_draper/decorator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RbsDraper::Decorator do
       RBS::DefinitionBuilder.new env: RBS::Environment.from_loader(loader).resolve_type_names
     end
 
-    context 'When a decorater without "delegate_all" given' do
+    context 'when a decorater without "delegate_all" given' do
       let(:klass) { AccountDecorator }
       let(:decorated_class) { nil }
       let(:expected) do
@@ -64,7 +64,7 @@ RSpec.describe RbsDraper::Decorator do
       end
     end
 
-    context 'When a decorater with "delegate_all" given' do
+    context 'when a decorater with "delegate_all" given' do
       let(:klass) { ArticleDecorator }
       let(:decorated_class) { nil }
       let(:expected) do
@@ -85,7 +85,7 @@ RSpec.describe RbsDraper::Decorator do
       end
     end
 
-    context "When a decorater having deep namespace given" do
+    context "when a decorater having deep namespace given" do
       let(:klass) { Mod::AccountDecorator }
       let(:decorated_class) { nil }
       let(:expected) do
@@ -105,7 +105,7 @@ RSpec.describe RbsDraper::Decorator do
       end
     end
 
-    context "When decorated_class argument given" do
+    context "when decorated_class argument given" do
       let(:klass) { ArticleDecorator }
       let(:decorated_class) { Account }
       let(:expected) do
@@ -126,7 +126,7 @@ RSpec.describe RbsDraper::Decorator do
       end
     end
 
-    context 'When a decorater with "delegates_finders" given' do
+    context 'when a decorater with "delegates_finders" given' do
       let(:klass) { ArticleFindersDecorator }
       let(:decorated_class) { nil }
       let(:expected) do


### PR DESCRIPTION
Add the `rubocop-rspec` plugin so this repository lints its specs, completing the full plugin set (numbered-params, rake, rbs_inline, rspec) shared across the sibling repositories.

- Add `rubocop-rspec` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`
- Configure `RSpec/NamedSubject` with the same setting used across the sibling repositories
- Reword `context` descriptions to lowercase `when …` (`RSpec/ContextWording`)
- Use an explicit `expect(subject)` instead of the implicit subject inside a named example (`RSpec/ImplicitSubject`)

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)